### PR TITLE
Window scroll API shim + use content scripts

### DIFF
--- a/css/content.css
+++ b/css/content.css
@@ -1,0 +1,22 @@
+:root {
+  --scrollbar-height: 0;
+  --scrollbar-width: 0;
+  height: 100vh !important;
+  overflow: hidden !important;
+  position: relative !important;
+  width: 100vw !important;
+}
+
+:root,
+body {
+  max-height: initial !important;
+  max-width: initial !important;
+  min-height: initial !important;
+  min-width: initial !important;
+}
+
+body {
+  height: calc(100vh + var(--scrollbar-height)) !important;
+  overflow: auto !important;
+  width: calc(100vw + var(--scrollbar-width)) !important;
+}

--- a/js/background.js
+++ b/js/background.js
@@ -1,20 +1,29 @@
-var hideScrollbars = true;
+var scrollbarsHidden = true;
+var contentScript;
 
-async function addScripts() {
-  await browser.tabs.executeScript({
-    file: '/js/qashto_firefox-hide-scrollbars.user.js',
-    allFrames: true
+function hideScrollbars () {
+  browser.contentScripts.register({
+    js: [{
+      file: "js/qashto_firefox-hide-scrollbars.user.js"
+    }],
+    css: [{
+      file: "css/content.css"
+    }],
+    matches: [ "<all_urls>" ],
+    runAt: "document_start"
+  }).then(contentScriptObject => {
+    contentScript = contentScriptObject;
   });
+
+  scrollbarsHidden = true;
 }
 
-function handleUpdated(tabId, changeInfo, tabInfo) {
-  if (changeInfo.url) {
-    console.log('Tab: ' + tabId +
-      ' URL changed to ' + changeInfo.url);
-    if (hideScrollbars) {
-      addScripts();
-    }
+function showScrollbars () {
+  if (contentScript) {
+    contentScript.unregister();
   }
+
+  scrollbarsHidden = false;
 }
 
-browser.tabs.onUpdated.addListener(handleUpdated);
+hideScrollbars();

--- a/js/popup.js
+++ b/js/popup.js
@@ -8,7 +8,8 @@ $(function() {
     let bg = await browser.runtime.getBackgroundPage();
 
     function updateButton($button) {
-      if (bg.hideScrollbars) {
+      console.log(bg.scrollbarsHidden);
+      if (bg.scrollbarsHidden) {
         $button.removeClass('toggle-ext-on');
         $button.addClass('toggle-ext-off');
         $button.html('show');
@@ -20,7 +21,11 @@ $(function() {
     }
 
     function update($button) {
-      bg.hideScrollbars = !bg.hideScrollbars;
+      if (bg.scrollbarsHidden) {
+        bg.showScrollbars();
+      } else {
+        bg.hideScrollbars();
+      }
       updateButton($button);
     }
 

--- a/manifest.json
+++ b/manifest.json
@@ -27,7 +27,8 @@
     "webRequestBlocking",
     "*://*/*",
     "tabs",
-    "storage"
+    "storage",
+    "<all_urls>"
   ],
   "short_name": "hide-scrollbars",
   "version": "2.0.0"


### PR DESCRIPTION
Scroll event listeners registered on `window` or `document` will be forwarded to `<body>`. `document.scrollingElement` is now `<body>` and `document.onscroll` also registers to `<body>`.

`window` properties representing `<body>` state:
* `window.scrollX`
* `window.scrollY`
* `window.pageXOffset`
* `window.pageYOffset`

... methods:

* `window.scroll`
* `window.scrollTo`
* `window.scrollBy`

Seemed a bit complex to have the userscript too, since content scripts have a different context it gets a little messy, but, you can do anything you want with this.
