### PR TITLE
Add userscript shim and fix getter/setter definition

### DIFF
--- a/js/pageContext.js
+++ b/js/pageContext.js
@@ -1,0 +1,22 @@
+let documentScrollHandler;
+Object.defineProperties(Document.prototype, {
+  scrollingElement: {
+    get() {
+      return document.body;
+    }
+  },
+  onscroll: {
+    get() {
+      return documentScrollHandler;
+    },
+    set(listener) {
+      if (documentScrollHandler) {
+        document.body.removeEventListener("scroll", documentScrollHandler);
+      }
+      if (listener) {
+        documentScrollHandler = listener;
+        document.body.addEventListener('scroll', documentScrollHandler);
+      }
+    }
+  }
+});

--- a/manifest.json
+++ b/manifest.json
@@ -31,5 +31,6 @@
     "<all_urls>"
   ],
   "short_name": "hide-scrollbars",
-  "version": "2.0.3"
+  "version": "2.0.3",
+  "web_accessible_resources": ["js/pageContext.js"]
 }


### PR DESCRIPTION
`exportFunction`/`cloneInto` aren't available to userscripts, so this just gets that working. I'm don't think that the window properties (`scrollX`, `scrollY`, etc...) can't be defined from the page context (userscripts), so that bit will only work in the extension.

Forgot about it at the time, but I didn't do anything with the getter/setter definitions when I did all the structured cloning. They can't be passed that way, so a separate script needs to be added to the page context.

Has to be duplicated without any build process, unfortunately. Unless we did something hacky with `.toSource()`.