### PR TITLE
Fix absolutely positioned children on scrolling element

### DIFF
--- a/css/content.css
+++ b/css/content.css
@@ -3,7 +3,6 @@
   --scrollbar-width: 0;
   height: 100vh !important;
   overflow: hidden !important;
-  position: relative !important;
   width: 100vw !important;
 }
 
@@ -13,6 +12,7 @@ body {
   max-width: initial !important;
   min-height: initial !important;
   min-width: initial !important;
+  position: relative !important;
 }
 
 body {


### PR DESCRIPTION
Absolute positioned elements position themselves relative to the nearest positioned element. If `<body>` isn't positioned, that's relative to root, which essentially acts as `position: fixed` given that it has no scrolling.